### PR TITLE
Performance Optimization: replace flag checks with macros.

### DIFF
--- a/peppapeg.c
+++ b/peppapeg.c
@@ -32,15 +32,16 @@
 
 #include "peppapeg.h"
 
-# define IS_TIGHT(e) (((e)->flag & P4_FLAG_TIGHT) != 0)
-# define IS_SCOPED(e) (((e)->flag & P4_FLAG_SCOPED) != 0)
-# define IS_SPACED(e) (((e)->flag & P4_FLAG_SPACED) != 0)
-# define IS_SQUASHED(e) (((e)->flag & P4_FLAG_SQUASHED) != 0)
-# define IS_LIFTED(e) (((e)->flag & P4_FLAG_LIFTED) != 0)
+# define                        IS_TIGHT(e) (((e)->flag & P4_FLAG_TIGHT) != 0)
+# define                        IS_SCOPED(e) (((e)->flag & P4_FLAG_SCOPED) != 0)
+# define                        IS_SPACED(e) (((e)->flag & P4_FLAG_SPACED) != 0)
+# define                        IS_SQUASHED(e) (((e)->flag & P4_FLAG_SQUASHED) != 0)
+# define                        IS_LIFTED(e) (((e)->flag & P4_FLAG_LIFTED) != 0)
+# define                        IS_RULE(e) ((e)->id != 0)
 # define                        NO_ERROR(s) ((s)->err == P4_Ok)
 # define                        NO_MATCH(s) ((s)->err == P4_MatchError)
 
-#define                         autofree __attribute__ ((cleanup (cleanup_freep)))
+# define                        autofree __attribute__ ((cleanup (cleanup_freep)))
 
 P4_PRIVATE(void)
 cleanup_freep (void *p)
@@ -258,7 +259,7 @@ P4_NeedSquash(P4_Source* s, P4_Expression* e) {
  */
 P4_PRIVATE(bool)
 P4_NeedLift(P4_Source* s, P4_Expression* e) {
-    return !P4_IsRule(e) || IS_LIFTED(e) || P4_NeedSquash(s, e);
+    return !IS_RULE(e) || IS_LIFTED(e) || P4_NeedSquash(s, e);
 }
 
 
@@ -900,14 +901,14 @@ P4_Match(P4_Source* s, P4_Expression* e) {
     P4_Error     err = P4_Ok;
     P4_Token* result = NULL;
 
-    if (P4_IsRule(e) && (err = P4_PushFrame(s, e)) != P4_Ok) {
+    if (IS_RULE(e) && (err = P4_PushFrame(s, e)) != P4_Ok) {
         P4_RaiseError(s, err, "failed to push frame");
         return NULL;
     }
 
     result = P4_Expression_dispatch(s, e);
 
-    if (P4_IsRule(e) && (err = P4_PopFrame(s, NULL)) != P4_Ok) {
+    if (IS_RULE(e) && (err = P4_PopFrame(s, NULL)) != P4_Ok) {
         P4_RaiseError(s, err, "failed to pop frame");
         P4_DeleteToken(result);
         return NULL;

--- a/peppapeg.c
+++ b/peppapeg.c
@@ -194,6 +194,10 @@ P4_CaseCmpInsensitive(P4_String src, P4_String dst, size_t len) {
 
 /*
  * Determine if the implicit whitespace should be applied.
+ *
+ * XXX: As long as the state can be cached when the frame is pushed, we
+ * don't need to traverse the frame stack to know if loosen is needed.
+ *
  */
 P4_PRIVATE(bool)
 P4_NeedLoosen(P4_Source* s, P4_Expression* e) {
@@ -228,6 +232,10 @@ P4_NeedLoosen(P4_Source* s, P4_Expression* e) {
 
 /*
  * Determine if inner tokens should be generated.
+ *
+ * XXX: As long as the state can be cached when the frame is pushed, we
+ * don't need to traverse the frame stack to know if loosen is needed.
+ *
  */
 P4_PRIVATE(bool)
 P4_NeedSquash(P4_Source* s, P4_Expression* e) {
@@ -256,6 +264,7 @@ P4_NeedSquash(P4_Source* s, P4_Expression* e) {
  * 1. Intermediate expr.
  * 2. Bareness expr.
  * 3. Hollowed expr.
+ *
  */
 P4_PRIVATE(bool)
 P4_NeedLift(P4_Source* s, P4_Expression* e) {


### PR DESCRIPTION
This should reduce the number of execution instructions for issue 15.

```
--------------------------------------------------------------------------------
Ir
--------------------------------------------------------------------------------
401,588,183 (100.0%)  PROGRAM TOTALS

--------------------------------------------------------------------------------
Ir                    file:function
--------------------------------------------------------------------------------
345,401,053 (86.01%)  peppapeg.c:P4_NeedLoosen [/app/a.out]
 25,019,000 ( 6.23%)  peppapeg.c:P4_NeedSquash [/app/a.out]
  4,617,160 ( 1.15%)  ???:_int_free [/usr/lib64/libc-2.28.so]
  3,382,226 ( 0.84%)  ???:malloc [/usr/lib64/ld-2.28.so]
  2,595,108 ( 0.65%)  peppapeg.c:P4_Match'2 [/app/a.out]
  1,848,485 ( 0.46%)  ???:free [/usr/lib64/ld-2.28.so]
  1,841,351 ( 0.46%)  peppapeg.c:P4_MatchLiteral [/app/a.out]
  1,712,968 ( 0.43%)  ???:__strlen_avx2 [/usr/lib64/libc-2.28.so]
  1,705,988 ( 0.42%)  peppapeg.c:P4_MatchChoice'2 [/app/a.out]
  1,518,598 ( 0.38%)  peppapeg.c:P4_Expression_dispatch'2 [/app/a.out]
  1,260,936 ( 0.31%)  ???:strdup [/usr/lib64/ld-2.28.so]
  1,098,095 ( 0.27%)  peppapeg.c:P4_MatchRepeat [/app/a.out]
  1,092,247 ( 0.27%)  peppapeg.c:P4_RaiseError [/app/a.out]
  1,016,618 ( 0.25%)  ???:__memcpy_avx_unaligned_erms [/usr/lib64/libc-2.28.so]
    865,496 ( 0.22%)  peppapeg.c:P4_MatchSequence'2 [/app/a.out]
    806,160 ( 0.20%)  peppapeg.c:P4_RescueError [/app/a.out]
    791,322 ( 0.20%)  peppapeg.c:P4_GetPosition [/app/a.out]
    671,409 ( 0.17%)  peppapeg.c:P4_DeleteToken [/app/a.out]
    470,520 ( 0.12%)  peppapeg.c:P4_PushFrame [/app/a.out]
```

Before PR:

```
# time ./a.out
real    0m0.090s
user    0m0.084s
sys     0m0.003s
```
PR:

```
real	0m0.052s
user	0m0.048s
sys	0m0.001s
```