### PR TITLE
Use LinkedList for Stack Frames.

### DIFF
--- a/peppapeg.c
+++ b/peppapeg.c
@@ -32,13 +32,6 @@
 
 #include "peppapeg.h"
 
-# define LOOSEN 0x1
-# define SQUASH 0x10
-# define IS_SILENT(f) (((f) & SQUASH) != 0)
-# define SET_SILENT(f) ((f) |= SQUASH)
-# define IS_LOOSEN(f) (((f) & LOOSEN) != 0)
-# define SET_LOOSEN(f) ((f) |= LOOSEN)
-
 # define                        IS_TIGHT(e) (((e)->flag & P4_FLAG_TIGHT) != 0)
 # define                        IS_SCOPED(e) (((e)->flag & P4_FLAG_SCOPED) != 0)
 # define                        IS_SPACED(e) (((e)->flag & P4_FLAG_SPACED) != 0)

--- a/peppapeg.c
+++ b/peppapeg.c
@@ -382,7 +382,6 @@ P4_PushFrame(P4_Source* s, P4_Expression* e) {
     s->frame_stack_size++;
     frame->expr = e;
     frame->next = top;
-    if (top) top->prev = frame;
     s->frame_stack = frame;
 
     return P4_Ok;
@@ -390,7 +389,7 @@ P4_PushFrame(P4_Source* s, P4_Expression* e) {
 
 
 /*
- * Pop e from s->frames.
+ * Pop top from s->frames.
  */
 P4_PRIVATE(P4_Error)
 P4_PopFrame(P4_Source* s, P4_Frame* f) {

--- a/peppapeg.c
+++ b/peppapeg.c
@@ -1356,7 +1356,6 @@ P4_CreateSource(P4_String content, P4_RuleID rule_id) {
     source->root = NULL;
     source->frames = NULL;
     source->frames_len = 0;
-    source->frames_cap = 0;
     source->whitespacing = false;
     return source;
 }

--- a/peppapeg.h
+++ b/peppapeg.h
@@ -176,7 +176,6 @@ typedef struct P4_Source {
     bool                    whitespacing;
     struct P4_Frame*        frames;
     uint64_t                frames_len;
-    uint64_t*               frame_flags;
 } P4_Source;
 
 typedef struct P4_Expression {

--- a/peppapeg.h
+++ b/peppapeg.h
@@ -160,11 +160,12 @@ typedef struct P4_Source {
     P4_Error                err;
     P4_String               errmsg;
     struct P4_Token*        root;
+    bool                    verbose;
+    bool                    whitespacing;
     struct P4_Expression**  frames;
     uint64_t                frames_len;
     uint64_t                frames_cap;
-    bool                    verbose;
-    bool                    whitespacing;
+    uint64_t*               frame_flags;
 } P4_Source;
 
 typedef struct P4_Expression {

--- a/peppapeg.h
+++ b/peppapeg.h
@@ -176,7 +176,6 @@ typedef struct P4_Source {
     bool                    whitespacing;
     struct P4_Frame*        frames;
     uint64_t                frames_len;
-    uint64_t                frames_cap;
     uint64_t*               frame_flags;
 } P4_Source;
 

--- a/peppapeg.h
+++ b/peppapeg.h
@@ -159,6 +159,9 @@ typedef struct P4_Frame {
     bool                    space;
     /* Whether silencing is applicable to frame & frame dependents. */
     bool                    silent;
+
+    struct P4_Frame*        prev;
+    struct P4_Frame*        next;
 } P4_Frame;
 
 typedef struct P4_Source {

--- a/peppapeg.h
+++ b/peppapeg.h
@@ -174,8 +174,8 @@ typedef struct P4_Source {
     struct P4_Token*        root;
     bool                    verbose;
     bool                    whitespacing;
-    struct P4_Frame*        frames;
-    uint64_t                frames_len;
+    struct P4_Frame*        frame_stack;
+    size_t                  frame_stack_size;
 } P4_Source;
 
 typedef struct P4_Expression {

--- a/peppapeg.h
+++ b/peppapeg.h
@@ -159,8 +159,7 @@ typedef struct P4_Frame {
     bool                    space;
     /* Whether silencing is applicable to frame & frame dependents. */
     bool                    silent;
-
-    struct P4_Frame*        prev;
+    /* The next frame in the stack. */
     struct P4_Frame*        next;
 } P4_Frame;
 
@@ -174,7 +173,9 @@ typedef struct P4_Source {
     struct P4_Token*        root;
     bool                    verbose;
     bool                    whitespacing;
+    /* The top frame in the stack. */
     struct P4_Frame*        frame_stack;
+    /* The size of frame stack. */
     size_t                  frame_stack_size;
 } P4_Source;
 

--- a/peppapeg.h
+++ b/peppapeg.h
@@ -152,6 +152,15 @@ typedef enum {
     P4_StackError           = 10,
 } P4_Error;
 
+typedef struct P4_Frame {
+    /* The current matching expression for the frame. */
+    struct P4_Expression*   expr;
+    /* Whether spacing is applicable to frame & frame dependents. */
+    bool                    space;
+    /* Whether silencing is applicable to frame & frame dependents. */
+    bool                    silent;
+} P4_Frame;
+
 typedef struct P4_Source {
     struct P4_Grammar*      grammar;
     P4_RuleID               rule_id;
@@ -162,7 +171,7 @@ typedef struct P4_Source {
     struct P4_Token*        root;
     bool                    verbose;
     bool                    whitespacing;
-    struct P4_Expression**  frames;
+    struct P4_Frame*        frames;
     uint64_t                frames_len;
     uint64_t                frames_cap;
     uint64_t*               frame_flags;


### PR DESCRIPTION
Inside the stack frame, the silent and space states are also cached so we don't need the heavy lift of using NeedSquash & NeedLoosen.

The performance optimization is significant:

Running #15 against the current HEAD (10x faster than #15):

```c
time ./a.out
real	0m0.014s
user	0m0.006s
sys	0m0.004s
```

See callgrind output: https://gist.github.com/soasme/f31ea5f78420304a1b12b434a4a808e9