### PR TITLE
Performance Optimization: Reduce strlen calls in literal matching. 500% faster.

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,6 @@
 - [ ] peg: left recursive: https://tratt.net/laurie/research/pubs/html/tratt__direct_left_recursive_parsing_expression_grammars/ https://github.com/orlandohill/peg-left-recursion. introduce left_recursion, right_recursion in sequence.
 - [ ] peg: describe grammar AST using ADSL-style rules.
 - [ ] perf: pre-alloc tokens.
-- [ ] perf: Cache literal len or use better string structure internally.
 - [ ] perf: trace: add a tracer in P4_Source. When matching, annotate the tracer. An additional tool can aggregate data and output a DOT / compile to png. Similar: https://textx.github.io/Arpeggio/stable/debugging/#parser-debug-mode https://ohmlang.github.io/editor/
 - [ ] perf: tracer: https://pegjs.org/documentation
       https://github.com/orlandohill/peg-left-recursion
@@ -70,6 +69,7 @@
 - [ ] peg: support Python-style INDENT rule.
 - [ ] api: print grammar and/or rules.
 - [ ] refactor: move some variables to `frame` to reduce function frame size.
+- [x] perf: Cache literal len or use better string structure internally.
 - [x] peg: ~~`@sibling_to_descdent`. can be used to transform cases like toml [key1.key2], key2 should be a child of key1.~~ This can be done via right recursion: key = identifier "." key / identifier;
 - [x] peg: right_recursion. updated right recursion in spec. v1.16.0
 - [x] peg: left_recursion. can be used to transform cases like expression: `a = b @left_recursion (minus/plus/mul/div) b`, the left side of `@left_recursion` is operand, the right side is infix and the other operand. Given 1+2+3, it will produce `{{1, +, 2}, + 3}`. v1.16.0

--- a/peppa.c
+++ b/peppa.c
@@ -575,6 +575,7 @@ struct P4_Expression {
         /** Used by P4_Literal and P4_BackReference. */
         struct {
             P4_String               literal;
+            size_t                  literal_len;
             bool                    sensitive;
             size_t                  backref_index;
         };
@@ -1790,9 +1791,9 @@ match_literal(P4_Source* s, P4_Expression* e) {
         return NULL;
     }
 
-    size_t len = strlen(e->literal);
-    size_t slen = strlen(str);
-    if (slen < len) {
+    size_t len = e->literal_len;
+    size_t rest = s->slice.stop.pos - s->pos;
+    if (rest < len) {
         P4_MatchRaisef(s, P4_MatchError, "expect %s (len %zu)",
                 s->frame_stack->rule->name, len);
         return NULL;
@@ -2570,6 +2571,7 @@ P4_CreateLiteral(const P4_String literal, bool sensitive) {
     expr->flag = 0;
     expr->name = NULL;
     expr->literal = STRDUP(literal);
+    expr->literal_len = strlen(literal);
     expr->sensitive = sensitive;
     return expr;
 }


### PR DESCRIPTION
A bottleneck on the performance is spotted. Given the following callgrind report, strlen is called frequently.

```
root@e9e1f33a922d:/app/buildlinux# callgrind_annotate callgrind.out.4864
--------------------------------------------------------------------------------
Profile data file 'callgrind.out.4864' (creator: callgrind-3.15.0)
--------------------------------------------------------------------------------
I1 cache:
D1 cache:
LL cache:
Timerange: Basic block 0 - 2999929205
Trigger: Program termination
Profiled target:  ./cli ast --grammar-file ../tests/golang-v1.17.peg --grammar-entry SourceFile ../tables.go (PID 4864, part 1)
Events recorded:  Ir
Events shown:     Ir
Event sort order: Ir
Thresholds:       99
Include dirs:
User annotated:
Auto-annotation:  off

--------------------------------------------------------------------------------
Ir
--------------------------------------------------------------------------------
17,147,795,601  PROGRAM TOTALS

--------------------------------------------------------------------------------
Ir             file:function
--------------------------------------------------------------------------------
5,671,628,114  /build/glibc-eX1tMB/glibc-2.31/string/../sysdeps/x86_64/multiarch/strlen-avx2.S:__strlen_avx2 [/usr/lib/x86_64-linux-gnu/libc-2.31.so]
2,285,786,104  /build/glibc-eX1tMB/glibc-2.31/stdio-common/vfprintf-internal.c:__vfprintf_internal [/usr/lib/x86_64-linux-gnu/libc-2.31.so]
2,082,168,585  /build/glibc-eX1tMB/glibc-2.31/libio/genops.c:_IO_default_xsputn [/usr/lib/x86_64-linux-gnu/libc-2.31.so]
  751,814,539  /build/glibc-eX1tMB/glibc-2.31/malloc/malloc.c:_int_free [/usr/lib/x86_64-linux-gnu/libc-2.31.so]
  745,634,925  /app/peppa.c:push_frame [/app/buildlinux/libpeppa.so]
  727,083,049  /app/peppa.c:match_expression'2 [/app/buildlinux/libpeppa.so]
```

Compare the `time` stats:

Before:

```
real	0m47.054s
user	0m44.259s
sys	0m0.234s
```

After

```
real	0m12.089s
user	0m9.655s
sys	0m0.107s
```