### PR TITLE
Performance Optimization: Replace errmsg with error struct.

### DIFF
--- a/peppa.c
+++ b/peppa.c
@@ -2424,12 +2424,6 @@ finalize:
 
     /* clean up */
     P4_DeleteNode(s->grammar, result);
-    /*
-    if (e->name != NULL && s->errmsg[0] == 0) {
-        P4_MatchRaisef(s, s->err, "expect %s", e->name);
-    }
-    */
-
     return NULL;
 }
 

--- a/peppa.c
+++ b/peppa.c
@@ -3173,12 +3173,6 @@ P4_GetErrorMessage(P4_Source* source) {
         case E_INVALID_UNICODE_CHAR:
             strcat(source->errmsg, " (invalid unicode char)");
             break;
-        case E_INVALID_UNICODE_PROPERTY:
-            strcat(source->errmsg, " (invalid unicode property)");
-            break;
-        case E_INVALID_UNICODE_CATEGORY:
-            strcat(source->errmsg, " (invalid unicode category)");
-            break;
         case E_NO_SUCH_RULE:
             strcat(source->errmsg, " (no such rule)");
             break;

--- a/peppa.h
+++ b/peppa.h
@@ -254,6 +254,28 @@ typedef enum {
     P4_CutError             = 12
 } P4_Error;
 
+# define E_WRONG_LIT           10000
+# define E_BACKREF_OUT_REACHED 10001
+# define E_BACKREF_TO_SELF     10002
+# define E_TEXT_TOO_SHORT      10003
+# define E_OUT_RANGED          10004
+# define E_INVALID_UNICODE_CHAR    10005
+# define E_INVALID_UNICODE_PROPERTY 10006
+# define E_INVALID_UNICODE_CATEGORY 10007
+# define E_NO_SUCH_RULE        10008
+# define E_NO_ALTERNATIVE       10009
+# define E_NO_PROGRESSING       10010
+# define E_INSUFFICIENT_REPEAT  10011
+# define E_INSUFFICIENT_REPEAT2 10012
+# define E_EXCESSIVE_REPEAT     10013
+# define E_LEFT_RECUR_NO_LIFT   10014
+# define E_VIOLATE_NEGATIVE     10015
+# define E_MAX_RECURSION        10016
+# define E_INVALID_MATCH_CALLBACK 10017
+# define E_INVALID_ERROR_CALLBACK 10018
+# define E_NO_EXPR              10019
+# define E_WRONG_BACKREF        10020
+
 /*
  *
  * ████████╗██╗░░░██╗██████╗░███████╗██████╗░███████╗███████╗░██████╗

--- a/tests/test_back_reference_spec.json
+++ b/tests/test_back_reference_spec.json
@@ -39,7 +39,7 @@
         "tests": [
             {
                 "I": "23",
-                "E": "MatchError: line 1:2, expect R1 (char '2')"
+                "E": "MatchError: line 1:2, expect R1 (back reference not match)"
             }
         ]
     },

--- a/tests/test_left_recursion.c
+++ b/tests/test_left_recursion.c
@@ -325,7 +325,7 @@ void test_left_recursion_cannot_use_with_lifted(void) {
         P4_PegError,
         P4_Parse(grammar, source)
     );
-    TEST_ASSERT_EQUAL_STRING("line 1:2, left recursion rule entry cannot be lifted", P4_GetErrorMessage(source));
+    TEST_ASSERT_EQUAL_STRING("line 1:2, expect entry (left recursion rule entry cannot be lifted)", P4_GetErrorMessage(source));
     P4_DeleteSource(source);
     P4_DeleteGrammar(grammar);
 }

--- a/tests/test_left_recursion_spec.json
+++ b/tests/test_left_recursion_spec.json
@@ -40,7 +40,7 @@
             },
             {
                 "I": "",
-                "E": "MatchError: line 1:1, expect A"
+                "E": "MatchError: line 1:1, expect A (char 'a')"
             }
         ]
     },
@@ -103,7 +103,7 @@
             },
             {
                 "I": "",
-                "E": "MatchError: line 1:1, expect A"
+                "E": "MatchError: line 1:1, expect B (char 'b')"
             }
         ]
     },

--- a/tests/test_literal_spec.json
+++ b/tests/test_literal_spec.json
@@ -59,7 +59,7 @@
             },
             {
                 "I": "",
-                "E": "MatchError: line 1:1, expect R1 (len 11)"
+                "E": "MatchError: line 1:1, expect R1 (char 'H')"
             }
         ]
     },

--- a/tests/test_toml_v1_0_spec.json
+++ b/tests/test_toml_v1_0_spec.json
@@ -2450,7 +2450,7 @@
             {
                 "desc": "multi-null",
                 "I": "multi-null = \"\"\"null\u0000\"\"\"\n",
-                "E": "CutError: line 1:21, expect ml_basic_string (at least 3 repetitions)"
+                "E": "CutError: line 1:21, expect ml_basic_string (insufficient repetitions)"
             },
             {
                 "desc": "multi-us",
@@ -2470,7 +2470,7 @@
             {
                 "desc": "rawmulti-null",
                 "I": "rawmulti-null = '''null\u0000'''\n",
-                "E": "CutError: line 1:24, expect ml_literal_string (at least 3 repetitions)"
+                "E": "CutError: line 1:24, expect ml_literal_string (insufficient repetitions)"
             },
             {
                 "desc": "rawmulti-us",


### PR DESCRIPTION
Given [tables.go](https://github.com/golang/go/blob/master/src/unicode/tables.go),

Before:
```
$ time ./cli ast --grammar-file ../tests/golang-v1.17.peg --grammar-entry SourceFile ../tables.go > /dev/null

real	0m4.781s
user	0m3.879s
sys	0m0.022s
```

After:
```
$ time ./cli ast --grammar-file ../tests/golang-v1.17.peg --grammar-entry SourceFile ../tables.go > /dev/null

real	0m1.253s
user	0m0.843s
sys	0m0.018s
```

Conclusion:

The change will cut down the execution time by 78%.